### PR TITLE
Introduced a CutCircuit class (WIP) to hold the entire circuit

### DIFF
--- a/src/cutqc2/core/cut_circuit.py
+++ b/src/cutqc2/core/cut_circuit.py
@@ -1,0 +1,52 @@
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import UnitaryGate
+from qiskit.circuit.quantumregister import Qubit
+from qiskit.circuit.quantumcircuitdata import CircuitInstruction
+
+
+class WireCutGate(UnitaryGate):
+    """
+    Custom gate to represent a wire cut in a quantum circuit.
+    """
+
+    def __init__(self):
+        super().__init__(data=[[1, 0], [0, 1]], num_qubits=1, label="✂️")
+        # The super constructor initializes name as "unitary" - use our own
+        self.name = "cut"
+
+
+class CutCircuit:
+    def __init__(
+        self,
+        circuit: QuantumCircuit,
+        cut_qubits_and_positions: list[tuple[Qubit, int]] | None = None,
+    ):
+        self.circuit = circuit
+        for cut_qubit_and_position in cut_qubits_and_positions or []:
+            self.add_cut(cut_qubit_and_position)
+
+    def __str__(self):
+        return str(self.circuit)
+
+    def add_cut(self, cut_qubit_and_position: tuple[Qubit, int]) -> QuantumCircuit:
+        """
+        Add a cut to the circuit at the specified position.
+        Args:
+            cut_qubit_and_position: A tuple containing the Qubit to cut and the position
+                                    in the wire where the cut should be made.
+                                    The position is a 0-indexed integer indicating the gate position
+                                    on the wire 'after' which the cut should be made.
+                                    This tuple format is what legacy CutQC code mostly uses.
+        Returns:
+            QuantumCircuit: The modified circuit with the cut added.
+        """
+        cut_qubit, cut_position = cut_qubit_and_position
+        cut_instr = CircuitInstruction(WireCutGate(), qubits=(cut_qubit,))
+
+        cut_wire_position = 0
+        for i, instr in enumerate(self.circuit.data):
+            if cut_qubit in instr.qubits:  # we're on the right wire
+                if cut_wire_position > cut_position:
+                    self.circuit.data.insert(i, cut_instr)
+                    break
+                cut_wire_position += 1

--- a/tests/test_cut_circuit.py
+++ b/tests/test_cut_circuit.py
@@ -1,0 +1,36 @@
+import textwrap
+import pytest
+from qiskit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister, Qubit
+from cutqc2.core.cut_circuit import CutCircuit
+
+
+@pytest.fixture(scope="module")
+def simple_circuit() -> QuantumCircuit:
+    qc = QuantumCircuit(3)
+    qc.reset(0)
+    qc.reset(1)
+    qc.reset(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.cx(0, 2)
+
+    return qc
+
+
+def test_cut_solution_str(simple_circuit):
+    cut_circuit = CutCircuit(
+        simple_circuit,
+        cut_qubits_and_positions=[(Qubit(QuantumRegister(3, "q"), 0), 2)],
+    )
+    got_str = str(cut_circuit)
+    expected_str = textwrap.dedent("""
+                      ┌───┐     ┌────┐     
+            q_0: ─|0>─┤ H ├──■──┤ ✂️ ├──■──
+                      └───┘┌─┴─┐└────┘  │  
+            q_1: ─|0>──────┤ X ├────────┼──
+                           └───┘      ┌─┴─┐
+            q_2: ─|0>─────────────────┤ X ├
+                                      └───┘
+    """).strip("\n")
+    assert got_str == expected_str


### PR DESCRIPTION
I really liked pennylane's representation of a cut as simply being a placeholder node in the circuit - that way the entire cut circuit can be thought of as an individual unit and carried over from one function to another just like any other `QuantumCircuit`, rather than carrying around several circuits, dictionaries and mappings.

Those sub-circuits are of courses needed at some point, but not when cuts are introduced.

This is a somewhat parallel effort wrt the DAG stuff, but the two will converge at some point, so I'm sending a PR towards the `vb/dag` branch.